### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased] - (release date)
 
+## [0.1.2] - 2022-08-13
+
 ### Fixed
 
 - Documentation: typo in README
@@ -20,6 +22,7 @@
 Initial version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/matthias-stemmler/funcmap/tree/v0.1.0

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ order to use it, add this to the `dependencies` table of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-funcmap = "0.1.1"
+funcmap = "0.1.2"
 ```
 
 ## Usage

--- a/crates-io.md
+++ b/crates-io.md
@@ -24,7 +24,7 @@ order to use it, add this to the `dependencies` table of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-funcmap = "0.1.1"
+funcmap = "0.1.2"
 ```
 
 ## Usage
@@ -119,8 +119,8 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-[examples]: https://github.com/matthias-stemmler/funcmap/tree/v0.1.1/funcmap/examples
-[docs]: https://docs.rs/funcmap/0.1.1/funcmap/
-[`funcmap`]: https://docs.rs/funcmap/0.1.1/funcmap/trait.FuncMap.html
-[`tryfuncmap`]: https://docs.rs/funcmap/0.1.1/funcmap/trait.TryFuncMap.html
-[`func_map`]: https://docs.rs/funcmap/0.1.1/funcmap/trait.FuncMap.html#tymethod.func_map
+[examples]: https://github.com/matthias-stemmler/funcmap/tree/v0.1.2/funcmap/examples
+[docs]: https://docs.rs/funcmap/0.1.2/funcmap/
+[`funcmap`]: https://docs.rs/funcmap/0.1.2/funcmap/trait.FuncMap.html
+[`tryfuncmap`]: https://docs.rs/funcmap/0.1.2/funcmap/trait.TryFuncMap.html
+[`func_map`]: https://docs.rs/funcmap/0.1.2/funcmap/trait.FuncMap.html#tymethod.func_map

--- a/funcmap/Cargo.toml
+++ b/funcmap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "funcmap"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Matthias Stemmler <matthias.stemmler@gmail.com>"]
 edition = "2021"
 rust-version = "1.56" # should be the same as in Cargo.toml of funcmap_derive, docs and MSRV job
@@ -18,4 +18,4 @@ alloc = []
 std = ["alloc"]
 
 [dependencies]
-"funcmap_derive" = { version = "=0.1.1", path = "../funcmap_derive" }
+"funcmap_derive" = { version = "=0.1.2", path = "../funcmap_derive" }

--- a/funcmap_derive/Cargo.toml
+++ b/funcmap_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "funcmap_derive"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.56" # should be the same as in Cargo.toml of funcmap, docs and MSRV job
 description = "Derivable functorial mappings for Rust"


### PR DESCRIPTION
<!-- VERSION:0.1.2 -->

| Name                   | Value                                              |
| ---------------------- | -------------------------------------------------- |
| **Version**            | `0.1.2`             |
| **Version bump type**  | `semantic`                   |
| **Version bump level** | `patch`                  |
| **Base branch**        | `main`                           |

## [0.1.2] - 2022-08-13

### Fixed

- Documentation: typo in README

[0.1.2]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.1...v0.1.2