### PR TITLE
fix: generate correct code for single-element tuple types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - (release date)
 
+### Fixed
+
+- Fixed derive macro generating incorrect code for single-element tuple types like `(T,)`
+
 ## [0.1.6] - 2025-10-27
 
 ### Changed

--- a/funcmap_derive/src/ident_collector.rs
+++ b/funcmap_derive/src/ident_collector.rs
@@ -56,13 +56,13 @@ impl IdentCollector {
 
         (0..=usize::MAX)
             .flat_map(|iteration| {
-                (desired_letter..='Z').chain('A'..=desired_letter).map(
-                    move |letter| match iteration {
+                (desired_letter..='Z')
+                    .chain('A'..desired_letter)
+                    .map(move |letter| match iteration {
                         0 => letter.to_string(),
                         1 => format!("__FUNCMAP_{letter}"),
                         i => format!("__FUNCMAP_{letter}{i}"),
-                    },
-                )
+                    })
             })
             .find(|letter| !self.idents.contains(letter))
             .unwrap()

--- a/funcmap_derive/src/map.rs
+++ b/funcmap_derive/src/map.rs
@@ -307,7 +307,7 @@ impl<'ast> Mapper<'ast> {
                     })
                     .collect::<Result<Vec<_>, _>>()?;
 
-                Ok(quote!((#(#mapped),*)))
+                Ok(quote!((#(#mapped,)*)))
             }
 
             Type::BareFn(..) => Err(syn::Error::new_spanned(

--- a/funcmap_tests/tests/single_param.rs
+++ b/funcmap_tests/tests/single_param.rs
@@ -73,6 +73,17 @@ fn tuple_entry_of_generic_param_type_is_mapped() {
     assert_eq!(dst, Test((T2, 42, T2)));
 }
 
+#[test]
+fn single_element_tuple_is_mapped() {
+    #[derive(FuncMap, Debug, PartialEq)]
+    struct Test<T>((T,));
+
+    let src = Test((T1,));
+    let dst = src.func_map(|_| T2);
+
+    assert_eq!(dst, Test((T2,)));
+}
+
 #[derive(Debug, PartialEq)]
 struct T1;
 


### PR DESCRIPTION
The tuple code generation used `(#(#mapped),*)` which produces `(expr)` for single-element tuples — a parenthesized expression, not a tuple. Changed to `(#(#mapped,)*)` which correctly generates `(expr,)`.

Also fix duplicate letter in ident_collector iteration by using an exclusive upper bound in the alphabet chain.