### PR TITLE
Release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased] - (release date)
 
+## [0.1.8] - 2026-04-17
+
 ### Changed
 
 - Increased MSRV to `1.85`
@@ -59,7 +61,8 @@
 Initial version
 
 <!-- next-url -->
-[Unreleased]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.7...HEAD
+[Unreleased]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.4...v0.1.5

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ order to use it, add this to the `dependencies` table of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-funcmap = "0.1.7"
+funcmap = "0.1.8"
 ```
 
 ## Usage

--- a/crates-io.md
+++ b/crates-io.md
@@ -24,7 +24,7 @@ order to use it, add this to the `dependencies` table of your `Cargo.toml`:
 
 ```toml
 [dependencies]
-funcmap = "0.1.7"
+funcmap = "0.1.8"
 ```
 
 ## Usage
@@ -119,8 +119,8 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-[examples]: https://github.com/matthias-stemmler/funcmap/tree/v0.1.7/funcmap/examples
-[docs]: https://docs.rs/funcmap/0.1.7/funcmap/
-[`funcmap`]: https://docs.rs/funcmap/0.1.7/funcmap/trait.FuncMap.html
-[`tryfuncmap`]: https://docs.rs/funcmap/0.1.7/funcmap/trait.TryFuncMap.html
-[`func_map`]: https://docs.rs/funcmap/0.1.7/funcmap/trait.FuncMap.html#tymethod.func_map
+[examples]: https://github.com/matthias-stemmler/funcmap/tree/v0.1.8/funcmap/examples
+[docs]: https://docs.rs/funcmap/0.1.8/funcmap/
+[`funcmap`]: https://docs.rs/funcmap/0.1.8/funcmap/trait.FuncMap.html
+[`tryfuncmap`]: https://docs.rs/funcmap/0.1.8/funcmap/trait.TryFuncMap.html
+[`func_map`]: https://docs.rs/funcmap/0.1.8/funcmap/trait.FuncMap.html#tymethod.func_map

--- a/funcmap/Cargo.toml
+++ b/funcmap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "funcmap"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Matthias Stemmler <matthias.stemmler@gmail.com>"]
 edition = "2021"
 rust-version = "1.85" # should be the same as in Cargo.toml of funcmap_derive, docs and MSRV job
@@ -18,4 +18,4 @@ alloc = []
 std = ["alloc"]
 
 [dependencies]
-"funcmap_derive" = { version = "=0.1.7", path = "../funcmap_derive" }
+"funcmap_derive" = { version = "=0.1.8", path = "../funcmap_derive" }

--- a/funcmap_derive/Cargo.toml
+++ b/funcmap_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "funcmap_derive"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 rust-version = "1.85" # should be the same as in Cargo.toml of funcmap, docs and MSRV job
 description = "Derivable functorial mappings for Rust"


### PR DESCRIPTION
<!-- VERSION:0.1.8 -->

| Name                   | Value                                              |
| ---------------------- | -------------------------------------------------- |
| **Version**            | `0.1.8`             |
| **Version bump type**  | `semantic`                   |
| **Version bump level** | `patch`                  |
| **Base branch**        | `main`                           |

## [0.1.8] - 2026-04-17

### Changed

- Increased MSRV to `1.85`

[0.1.8]: https://github.com/matthias-stemmler/funcmap/compare/v0.1.7...v0.1.8